### PR TITLE
Fix search resource filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.14](https://github.com/klappy/translation-helps-mcp/compare/v7.19.13...v7.19.14) (2025-12-10)
+
+### Bug Fixes
+
+- **search:** Respect AutoRAG's 50 result limit
+  - AutoRAG has a hard limit of 50 max_num_results
+  - Was trying to fetch 500 which caused "Too big" error
+  - Scripture filter now works but is limited by AutoRAG's 50 result cap
+
 ### [7.19.13](https://github.com/klappy/translation-helps-mcp/compare/v7.19.12...v7.19.13) (2025-12-10)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.15](https://github.com/klappy/translation-helps-mcp/compare/v7.19.14...v7.19.15) (2025-12-10)
+
+### Features
+
+- **indexer:** Chapter-level indexing for scripture
+  - Scripture now indexed at chapter level instead of book level
+  - Better search granularity - "love" will find more relevant chapters
+  - Each chapter is a separate searchable chunk with metadata
+  - Path structure: `{lang}/{org}/{resource}/{version}/{book}/{chapter}.md`
+  - Requires re-indexing: flush both R2 buckets to trigger workflow
+
+### Bug Fixes
+
+- **fetch-scripture:** Filter search results by requested language
+  - Was returning results from all languages when searching
+  - Now explicitly filters to match requested language parameter
+
 ### [7.19.14](https://github.com/klappy/translation-helps-mcp/compare/v7.19.13...v7.19.14) (2025-12-10)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.17](https://github.com/klappy/translation-helps-mcp/compare/v7.19.16...v7.19.17) (2025-12-10)
+
+### Features
+
+- **fetch-scripture:** Add `filter` parameter for stemmed regex search
+  - `search` = AutoRAG semantic (conceptually about X)
+  - `filter` = Stemmed regex (contains word X and variations)
+  - Example: `filter=love` matches love, loves, loved, loving, loveth
+  - Requires `reference` parameter (e.g., `reference=John`)
+  - Returns all matching verses with matched terms highlighted
+
 ### [7.19.16](https://github.com/klappy/translation-helps-mcp/compare/v7.19.15...v7.19.16) (2025-12-10)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.16](https://github.com/klappy/translation-helps-mcp/compare/v7.19.15...v7.19.16) (2025-12-10)
+
+### Bug Fixes
+
+- **search:** Infer language and organization from file path
+  - AutoRAG wasn't returning metadata, so language defaulted to 'en'
+  - Now extracts language/organization from path (e.g., `hi/translationCore-Create-BCS/...`)
+  - Fixes Hindi results appearing when searching for English
+  - Language and organization filters now work correctly
+
 ### [7.19.15](https://github.com/klappy/translation-helps-mcp/compare/v7.19.14...v7.19.15) (2025-12-10)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.13](https://github.com/klappy/translation-helps-mcp/compare/v7.19.12...v7.19.13) (2025-12-10)
+
+### Bug Fixes
+
+- **search:** Use actual resource codes instead of 'scripture' category
+  - `inferResourceFromPath` now returns actual codes (ult, ust, ueb, t4t) not 'scripture'
+  - Search results now show `resource: "ult"` instead of `resource: "scripture"`
+  - Consistent with how helps resources work (tn, tw, tq, ta)
+  - 'scripture' and 'bible' remain as convenience aliases for filtering
+  - Filter by specific resource: `resource=ult` or `resource=ust`
+  - Filter all scripture: `resource=scripture` (expands to ult, ust, ueb, t4t, glt, gst)
+
 ### [7.19.12](https://github.com/klappy/translation-helps-mcp/compare/v7.19.11...v7.19.12) (2025-12-10)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.10](https://github.com/klappy/translation-helps-mcp/compare/v7.19.9...v7.19.10) (2025-12-10)
+
+### Bug Fixes
+
+- **wrangler:** Add AI binding to preview environment for deploy previews
+  - Deploy previews were returning "AI binding not available"
+  - Added AI, KV, and R2 bindings to `[env.preview]` in wrangler.toml
+
 ### [7.19.9](https://github.com/klappy/translation-helps-mcp/compare/v7.19.8...v7.19.9) (2025-12-10)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.9](https://github.com/klappy/translation-helps-mcp/compare/v7.19.8...v7.19.9) (2025-12-10)
+
+### Bug Fixes
+
+- **search:** Fix client-side filtering causing empty results
+  - Made all client-side filters lenient for missing metadata fields
+  - Filters now only remove results that have a field AND it doesn't match
+  - Fixed `includeHelps` filter which was filtering out all hits with undefined resource
+  - Added diagnostic logging to track which filters AutoRAG isn't honoring server-side
+  - Filters affected: resource, language, organization, book, chapter, chunk_level, article_id
+
 ### [7.19.8](https://github.com/klappy/translation-helps-mcp/compare/v7.19.7...v7.19.8) (2025-12-06)
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.12](https://github.com/klappy/translation-helps-mcp/compare/v7.19.11...v7.19.12) (2025-12-10)
+
+### Bug Fixes
+
+- **fetch-scripture:** Fix search delegation filtering out all results
+  - Changed filter from `hit.type === 'bible'` (non-existent field) to checking `hit.resource`
+  - Now correctly filters for scripture resources: ult, ust, ueb, t4t, glt, gst
+  - Added `resource=scripture` param when delegating to /api/search to trigger expanded fetching
+  - Fixed `owner` param to `organization` to match search endpoint expectations
+  - Request 50 results from search to increase scripture hit chances
+
 ### [7.19.11](https://github.com/klappy/translation-helps-mcp/compare/v7.19.10...v7.19.11) (2025-12-10)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.19.11](https://github.com/klappy/translation-helps-mcp/compare/v7.19.10...v7.19.11) (2025-12-10)
+
+### Bug Fixes
+
+- **search:** Fetch more results from AutoRAG for scripture filtering
+  - When filtering by `scripture` or `bible`, fetch 10x more results (min 100, max 500)
+  - Scripture ranks lower in vector search for single-word queries like "love"
+  - By fetching more results, we increase chances of getting scripture hits to filter
+  - Client-side filtering then returns only scripture resources up to requested limit
+
 ### [7.19.10](https://github.com/klappy/translation-helps-mcp/compare/v7.19.9...v7.19.10) (2025-12-10)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.14",
+  "version": "7.19.15",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.24",
+  "version": "7.19.25",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.19",
+  "version": "7.19.20",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.18",
+  "version": "7.19.19",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.9",
+  "version": "7.19.10",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.10",
+  "version": "7.19.11",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.23",
+  "version": "7.19.24",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.11",
+  "version": "7.19.12",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.15",
+  "version": "7.19.16",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.8",
+  "version": "7.19.9",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.20",
+  "version": "7.19.21",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.21",
+  "version": "7.19.22",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.13",
+  "version": "7.19.14",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.27",
+  "version": "7.19.28",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.12",
+  "version": "7.19.13",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.17",
+  "version": "7.19.18",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.16",
+  "version": "7.19.17",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.28",
+  "version": "7.19.29",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.22",
+  "version": "7.19.23",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.25",
+  "version": "7.19.26",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.19.26",
+  "version": "7.19.27",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/src/config/endpoints/ScriptureEndpoints.ts
+++ b/src/config/endpoints/ScriptureEndpoints.ts
@@ -55,10 +55,19 @@ const SCRIPTURE_BASE_CONFIG: Partial<EndpointConfig> = {
       type: "string",
       required: false,
       description:
-        "Optional: Filter scripture by search query (e.g., 'love', 'believe'). Returns only verses matching the query.",
+        "Semantic search via AutoRAG - finds passages conceptually about the query (e.g., 'love' finds passages about love)",
       example: "love",
       min: 2,
       max: 100,
+    },
+    filter: {
+      type: "string",
+      required: false,
+      description:
+        "Keyword filter with stemming - finds all verses containing the word and variations (e.g., 'love' matches love, loves, loved, loving, loveth). Requires reference parameter.",
+      example: "love",
+      min: 2,
+      max: 50,
     },
     format: {
       type: "string",

--- a/src/config/endpoints/ScriptureEndpoints.ts
+++ b/src/config/endpoints/ScriptureEndpoints.ts
@@ -64,7 +64,7 @@ const SCRIPTURE_BASE_CONFIG: Partial<EndpointConfig> = {
       type: "string",
       required: false,
       description:
-        "Keyword filter with stemming - finds all verses containing the word and variations (e.g., 'love' matches love, loves, loved, loving, loveth). Use with reference (book/chapter) or resource (full translation search).",
+        "Keyword filter with stemming - finds verses containing the word and variations (e.g., 'love' matches love, loves, loved, loving, loveth). IMPORTANT: Requires either a 'reference' OR a specific 'resource' (ult/ust/t4t/ueb, NOT 'all'). Use testament=nt or testament=ot to limit scope.",
       example: "love",
       min: 2,
       max: 50,

--- a/src/config/endpoints/ScriptureEndpoints.ts
+++ b/src/config/endpoints/ScriptureEndpoints.ts
@@ -64,10 +64,18 @@ const SCRIPTURE_BASE_CONFIG: Partial<EndpointConfig> = {
       type: "string",
       required: false,
       description:
-        "Keyword filter with stemming - finds all verses containing the word and variations (e.g., 'love' matches love, loves, loved, loving, loveth). Requires reference parameter.",
+        "Keyword filter with stemming - finds all verses containing the word and variations (e.g., 'love' matches love, loves, loved, loving, loveth). Use with reference (book/chapter) or resource (full translation search).",
       example: "love",
       min: 2,
       max: 50,
+    },
+    testament: {
+      type: "string",
+      required: false,
+      description:
+        "Limit full-resource filter search to Old or New Testament. Only applies when using filter without reference.",
+      example: "nt",
+      options: ["ot", "nt"],
     },
     format: {
       type: "string",

--- a/src/contracts/ToolContracts.ts
+++ b/src/contracts/ToolContracts.ts
@@ -38,6 +38,20 @@ export interface TranslationWordToolArgs {
 // Define the exact response formatters
 export const ToolFormatters = {
   scripture: (data: any): string => {
+    // Handle filter response format (has 'matches' array)
+    if (data.matches && Array.isArray(data.matches)) {
+      if (data.matches.length === 0) {
+        return `No matches found for filter: ${data.filter || 'unknown'}`;
+      }
+      // Format filter matches
+      const header = `# Filter Results: "${data.filter}"\n\nFound ${data.totalMatches} matches\n\n`;
+      const matches = data.matches
+        .slice(0, 50) // Limit to first 50 for readability
+        .map((m: any) => `**${m.reference}** (${m.resource}): ${m.text}`)
+        .join("\n\n");
+      return header + matches + (data.totalMatches > 50 ? `\n\n... and ${data.totalMatches - 50} more matches` : '');
+    }
+    
     // Check both 'scripture' (singular - standard response format) and 'scriptures' (plural - legacy)
     const scriptureArray = data.scripture || data.scriptures;
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.19";
+export const VERSION = "7.19.20";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.21";
+export const VERSION = "7.19.22";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.23";
+export const VERSION = "7.19.24";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.24";
+export const VERSION = "7.19.25";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.17";
+export const VERSION = "7.19.18";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.12";
+export const VERSION = "7.19.13";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.16";
+export const VERSION = "7.19.17";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.28";
+export const VERSION = "7.19.29";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.13";
+export const VERSION = "7.19.14";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.15";
+export const VERSION = "7.19.16";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.26";
+export const VERSION = "7.19.28";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.18";
+export const VERSION = "7.19.19";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.14";
+export const VERSION = "7.19.15";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.10";
+export const VERSION = "7.19.12";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.25";
+export const VERSION = "7.19.26";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.8";
+export const VERSION = "7.19.10";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.22";
+export const VERSION = "7.19.23";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.19.20";
+export const VERSION = "7.19.21";
 
 export function getVersion(): string {
   return VERSION;

--- a/src/workers/indexer/types.ts
+++ b/src/workers/indexer/types.ts
@@ -84,9 +84,11 @@ export interface CommonMetadata {
 export interface ScriptureMetadata extends CommonMetadata {
   book: string;
   book_name: string;
-  /** Total verses in the book */
+  /** Chapter number (for chapter-level indexing) */
+  chapter?: number;
+  /** Total verses in the chunk (chapter or book) */
   verse_count: number;
-  /** Total chapters in the book */
+  /** Total chapters (1 for chapter-level, N for book-level) */
   chapter_count: number;
   /** Section titles extracted from USFM \s markers */
   sections?: string[];

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.16",
+	"version": "7.19.17",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.16",
+			"version": "7.19.17",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.10",
+	"version": "7.19.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.10",
+			"version": "7.19.12",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.17",
+	"version": "7.19.18",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.17",
+			"version": "7.19.18",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.18",
+	"version": "7.19.19",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.18",
+			"version": "7.19.19",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.28",
+	"version": "7.19.29",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.28",
+			"version": "7.19.29",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.20",
+	"version": "7.19.21",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.20",
+			"version": "7.19.21",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.23",
+	"version": "7.19.24",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.23",
+			"version": "7.19.24",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.21",
+	"version": "7.19.22",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.21",
+			"version": "7.19.22",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.22",
+	"version": "7.19.23",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.22",
+			"version": "7.19.23",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.15",
+	"version": "7.19.16",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.15",
+			"version": "7.19.16",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.19",
+	"version": "7.19.20",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.19",
+			"version": "7.19.20",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.12",
+	"version": "7.19.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.12",
+			"version": "7.19.13",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.24",
+	"version": "7.19.25",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.24",
+			"version": "7.19.25",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.14",
+	"version": "7.19.15",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.14",
+			"version": "7.19.15",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.8",
+	"version": "7.19.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.8",
+			"version": "7.19.10",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.25",
+	"version": "7.19.26",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.25",
+			"version": "7.19.26",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.13",
+	"version": "7.19.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.13",
+			"version": "7.19.14",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "translation-helps-ui",
-	"version": "7.19.26",
+	"version": "7.19.28",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "translation-helps-ui",
-			"version": "7.19.26",
+			"version": "7.19.28",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.18",
+	"version": "7.19.19",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.9",
+	"version": "7.19.10",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.21",
+	"version": "7.19.22",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.26",
+	"version": "7.19.27",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.13",
+	"version": "7.19.14",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.28",
+	"version": "7.19.29",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.24",
+	"version": "7.19.25",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.23",
+	"version": "7.19.24",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.14",
+	"version": "7.19.15",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.16",
+	"version": "7.19.17",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.15",
+	"version": "7.19.16",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.17",
+	"version": "7.19.18",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.11",
+	"version": "7.19.12",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.19",
+	"version": "7.19.20",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.27",
+	"version": "7.19.28",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.20",
+	"version": "7.19.21",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.8",
+	"version": "7.19.9",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.12",
+	"version": "7.19.13",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.25",
+	"version": "7.19.26",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.22",
+	"version": "7.19.23",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "translation-helps-ui",
 	"type": "module",
-	"version": "7.19.10",
+	"version": "7.19.11",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "node ../scripts/sync-version.js && vite build",

--- a/ui/src/lib/stemmedFilter.ts
+++ b/ui/src/lib/stemmedFilter.ts
@@ -1,0 +1,212 @@
+/**
+ * Stemmed Filter Utility
+ * 
+ * Generates stemmed regex patterns for comprehensive keyword filtering.
+ * Used across all resource endpoints for the `filter` parameter.
+ */
+
+/**
+ * Generate a stemmed regex pattern from a search term.
+ * Handles common English word variations including biblical/archaic forms.
+ * 
+ * @param term - The search term to stem
+ * @returns RegExp that matches the term and its variations
+ * 
+ * @example
+ * generateStemmedPattern('love')
+ * // Returns: /\b(love|loves|loved|loving|loveth|lovest)\b/gi
+ */
+export function generateStemmedPattern(term: string): RegExp {
+	const stems = new Set<string>();
+	const base = term.toLowerCase().trim();
+	
+	if (!base) {
+		throw new Error('Filter term cannot be empty');
+	}
+	
+	// Add the base term
+	stems.add(base);
+	
+	// Common English suffixes
+	stems.add(base + 's');         // love → loves
+	stems.add(base + 'es');        // search → searches
+	stems.add(base + 'd');         // love → loved
+	stems.add(base + 'ed');        // call → called
+	stems.add(base + 'ing');       // call → calling
+	stems.add(base + 'er');        // love → lover
+	stems.add(base + 'ers');       // love → lovers
+	stems.add(base + 'ly');        // love → lovely
+	
+	// Biblical/archaic forms (KJV style)
+	stems.add(base + 'eth');       // love → loveth
+	stems.add(base + 'est');       // love → lovest
+	stems.add(base + 'edst');      // love → lovedst
+	
+	// Handle words ending in 'e' (love → loving, not loveing)
+	if (base.endsWith('e')) {
+		const noE = base.slice(0, -1);
+		stems.add(noE + 'ing');      // love → loving
+		stems.add(noE + 'ed');       // love → loved (already covered but safe)
+		stems.add(noE + 'er');       // love → lover
+		stems.add(noE + 'ers');      // love → lovers
+		stems.add(noE + 'eth');      // love → loveth
+		stems.add(noE + 'est');      // love → lovest
+	}
+	
+	// Handle words ending in 'y' (glory → glories)
+	if (base.endsWith('y') && base.length > 2) {
+		const noY = base.slice(0, -1);
+		stems.add(noY + 'ies');      // glory → glories
+		stems.add(noY + 'ied');      // glory → gloried
+		stems.add(noY + 'ier');      // glory → glorier
+		stems.add(noY + 'iest');     // glory → gloriest
+	}
+	
+	// Handle double consonants for short words (stop → stopping)
+	if (base.length <= 4 && /[aeiou][bcdfghjklmnpqrstvwxz]$/.test(base)) {
+		const lastChar = base[base.length - 1];
+		stems.add(base + lastChar + 'ing');  // stop → stopping
+		stems.add(base + lastChar + 'ed');   // stop → stopped
+		stems.add(base + lastChar + 'er');   // stop → stopper
+	}
+	
+	// Build pattern with word boundaries
+	// Sort by length descending so longer matches are tried first
+	const sortedStems = [...stems].sort((a, b) => b.length - a.length);
+	const pattern = sortedStems.join('|');
+	
+	return new RegExp(`\\b(${pattern})\\b`, 'gi');
+}
+
+/**
+ * Result of a filter match
+ */
+export interface FilterMatch {
+	/** The matched text/content */
+	text: string;
+	/** Reference (e.g., "JHN 3:16" or article ID) */
+	reference: string;
+	/** Resource type (ult, ust, tn, tw, etc.) */
+	resource: string;
+	/** Language code */
+	language: string;
+	/** The matched terms found */
+	matchedTerms: string[];
+	/** Match score (number of matches) */
+	matchCount: number;
+}
+
+/**
+ * Apply stemmed filter to text content and extract matching segments.
+ * 
+ * @param content - The full content to search
+ * @param pattern - The stemmed regex pattern
+ * @param segmentParser - Function to parse content into searchable segments
+ * @returns Array of matching segments with metadata
+ */
+export function applyFilter<T>(
+	content: string,
+	pattern: RegExp,
+	segmentParser: (content: string) => T[],
+	segmentToFilterMatch: (segment: T, matches: string[]) => FilterMatch | null
+): FilterMatch[] {
+	const segments = segmentParser(content);
+	const results: FilterMatch[] = [];
+	
+	for (const segment of segments) {
+		// Reset regex lastIndex for each segment
+		pattern.lastIndex = 0;
+		
+		// Get segment text for matching
+		const segmentText = typeof segment === 'string' ? segment : JSON.stringify(segment);
+		const matches: string[] = [];
+		let match;
+		
+		while ((match = pattern.exec(segmentText)) !== null) {
+			matches.push(match[0]);
+		}
+		
+		if (matches.length > 0) {
+			const filterMatch = segmentToFilterMatch(segment, matches);
+			if (filterMatch) {
+				results.push(filterMatch);
+			}
+		}
+	}
+	
+	return results;
+}
+
+/**
+ * Parse scripture content into verses.
+ * Handles markdown format: "chapter:verse text"
+ */
+export function parseScriptureIntoVerses(
+	content: string,
+	book: string,
+	resource: string,
+	language: string
+): Array<{ text: string; reference: string; chapter: number; verse: number }> {
+	const verses: Array<{ text: string; reference: string; chapter: number; verse: number }> = [];
+	const lines = content.split('\n');
+	
+	for (const line of lines) {
+		// Match verse format: "3:16 For God so loved..."
+		const verseMatch = line.match(/^(\d+):(\d+)\s+(.+)$/);
+		if (verseMatch) {
+			const [, chapter, verse, text] = verseMatch;
+			verses.push({
+				text: text.trim(),
+				reference: `${book} ${chapter}:${verse}`,
+				chapter: parseInt(chapter, 10),
+				verse: parseInt(verse, 10)
+			});
+		}
+	}
+	
+	return verses;
+}
+
+/**
+ * Create an NDJSON streaming response
+ */
+export function createNDJSONStream(): {
+	stream: ReadableStream;
+	writer: {
+		write: (data: any) => void;
+		close: () => void;
+	};
+} {
+	let controller: ReadableStreamDefaultController;
+	const encoder = new TextEncoder();
+	
+	const stream = new ReadableStream({
+		start(c) {
+			controller = c;
+		}
+	});
+	
+	return {
+		stream,
+		writer: {
+			write: (data: any) => {
+				controller.enqueue(encoder.encode(JSON.stringify(data) + '\n'));
+			},
+			close: () => {
+				controller.close();
+			}
+		}
+	};
+}
+
+/**
+ * Create streaming response headers
+ */
+export function getStreamingHeaders(): HeadersInit {
+	return {
+		'Content-Type': 'application/x-ndjson',
+		'Transfer-Encoding': 'chunked',
+		'Cache-Control': 'no-cache',
+		'Connection': 'keep-alive'
+	};
+}

--- a/ui/src/lib/stemmedFilter.ts
+++ b/ui/src/lib/stemmedFilter.ts
@@ -35,18 +35,16 @@ export function generateStemmedPattern(term: string): RegExp {
 	stems.add(base + 'ing');       // call → calling
 	stems.add(base + 'er');        // love → lover
 	stems.add(base + 'ers');       // love → lovers
-	stems.add(base + 'ly');        // love → lovely
 	
 	// Biblical/archaic forms (KJV style)
 	stems.add(base + 'eth');       // love → loveth
 	stems.add(base + 'est');       // love → lovest
-	stems.add(base + 'edst');      // love → lovedst
 	
 	// Handle words ending in 'e' (love → loving, not loveing)
 	if (base.endsWith('e')) {
 		const noE = base.slice(0, -1);
 		stems.add(noE + 'ing');      // love → loving
-		stems.add(noE + 'ed');       // love → loved (already covered but safe)
+		stems.add(noE + 'ed');       // love → loved
 		stems.add(noE + 'er');       // love → lover
 		stems.add(noE + 'ers');      // love → lovers
 		stems.add(noE + 'eth');      // love → loveth
@@ -58,16 +56,6 @@ export function generateStemmedPattern(term: string): RegExp {
 		const noY = base.slice(0, -1);
 		stems.add(noY + 'ies');      // glory → glories
 		stems.add(noY + 'ied');      // glory → gloried
-		stems.add(noY + 'ier');      // glory → glorier
-		stems.add(noY + 'iest');     // glory → gloriest
-	}
-	
-	// Handle double consonants for short words (stop → stopping)
-	if (base.length <= 4 && /[aeiou][bcdfghjklmnpqrstvwxz]$/.test(base)) {
-		const lastChar = base[base.length - 1];
-		stems.add(base + lastChar + 'ing');  // stop → stopping
-		stems.add(base + lastChar + 'ed');   // stop → stopped
-		stems.add(base + lastChar + 'er');   // stop → stopper
 	}
 	
 	// Build pattern with word boundaries
@@ -76,137 +64,4 @@ export function generateStemmedPattern(term: string): RegExp {
 	const pattern = sortedStems.join('|');
 	
 	return new RegExp(`\\b(${pattern})\\b`, 'gi');
-}
-
-/**
- * Result of a filter match
- */
-export interface FilterMatch {
-	/** The matched text/content */
-	text: string;
-	/** Reference (e.g., "JHN 3:16" or article ID) */
-	reference: string;
-	/** Resource type (ult, ust, tn, tw, etc.) */
-	resource: string;
-	/** Language code */
-	language: string;
-	/** The matched terms found */
-	matchedTerms: string[];
-	/** Match score (number of matches) */
-	matchCount: number;
-}
-
-/**
- * Apply stemmed filter to text content and extract matching segments.
- * 
- * @param content - The full content to search
- * @param pattern - The stemmed regex pattern
- * @param segmentParser - Function to parse content into searchable segments
- * @returns Array of matching segments with metadata
- */
-export function applyFilter<T>(
-	content: string,
-	pattern: RegExp,
-	segmentParser: (content: string) => T[],
-	segmentToFilterMatch: (segment: T, matches: string[]) => FilterMatch | null
-): FilterMatch[] {
-	const segments = segmentParser(content);
-	const results: FilterMatch[] = [];
-	
-	for (const segment of segments) {
-		// Reset regex lastIndex for each segment
-		pattern.lastIndex = 0;
-		
-		// Get segment text for matching
-		const segmentText = typeof segment === 'string' ? segment : JSON.stringify(segment);
-		const matches: string[] = [];
-		let match;
-		
-		while ((match = pattern.exec(segmentText)) !== null) {
-			matches.push(match[0]);
-		}
-		
-		if (matches.length > 0) {
-			const filterMatch = segmentToFilterMatch(segment, matches);
-			if (filterMatch) {
-				results.push(filterMatch);
-			}
-		}
-	}
-	
-	return results;
-}
-
-/**
- * Parse scripture content into verses.
- * Handles markdown format: "chapter:verse text"
- */
-export function parseScriptureIntoVerses(
-	content: string,
-	book: string,
-	resource: string,
-	language: string
-): Array<{ text: string; reference: string; chapter: number; verse: number }> {
-	const verses: Array<{ text: string; reference: string; chapter: number; verse: number }> = [];
-	const lines = content.split('\n');
-	
-	for (const line of lines) {
-		// Match verse format: "3:16 For God so loved..."
-		const verseMatch = line.match(/^(\d+):(\d+)\s+(.+)$/);
-		if (verseMatch) {
-			const [, chapter, verse, text] = verseMatch;
-			verses.push({
-				text: text.trim(),
-				reference: `${book} ${chapter}:${verse}`,
-				chapter: parseInt(chapter, 10),
-				verse: parseInt(verse, 10)
-			});
-		}
-	}
-	
-	return verses;
-}
-
-/**
- * Create an NDJSON streaming response
- */
-export function createNDJSONStream(): {
-	stream: ReadableStream;
-	writer: {
-		write: (data: any) => void;
-		close: () => void;
-	};
-} {
-	let controller: ReadableStreamDefaultController;
-	const encoder = new TextEncoder();
-	
-	const stream = new ReadableStream({
-		start(c) {
-			controller = c;
-		}
-	});
-	
-	return {
-		stream,
-		writer: {
-			write: (data: any) => {
-				controller.enqueue(encoder.encode(JSON.stringify(data) + '\n'));
-			},
-			close: () => {
-				controller.close();
-			}
-		}
-	};
-}
-
-/**
- * Create streaming response headers
- */
-export function getStreamingHeaders(): HeadersInit {
-	return {
-		'Content-Type': 'application/x-ndjson',
-		'Transfer-Encoding': 'chunked',
-		'Cache-Control': 'no-cache',
-		'Connection': 'keep-alive'
-	};
 }

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.12';
+export const VERSION = '7.19.13';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.8';
+export const VERSION = '7.19.10';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.22';
+export const VERSION = '7.19.23';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.18';
+export const VERSION = '7.19.19';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.16';
+export const VERSION = '7.19.17';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.21';
+export const VERSION = '7.19.22';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.15';
+export const VERSION = '7.19.16';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.25';
+export const VERSION = '7.19.26';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.26';
+export const VERSION = '7.19.28';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.19';
+export const VERSION = '7.19.20';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.13';
+export const VERSION = '7.19.14';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.10';
+export const VERSION = '7.19.12';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.14';
+export const VERSION = '7.19.15';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.23';
+export const VERSION = '7.19.24';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.28';
+export const VERSION = '7.19.29';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.24';
+export const VERSION = '7.19.25';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.20';
+export const VERSION = '7.19.21';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.19.17';
+export const VERSION = '7.19.18';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/routes/api/fetch-scripture/+server.ts
+++ b/ui/src/routes/api/fetch-scripture/+server.ts
@@ -6,7 +6,9 @@
  * 
  * Parameters:
  * - search: AutoRAG semantic search (conceptually about X)
- * - filter: Stemmed regex filter (contains word X) - requires reference
+ * - filter: Stemmed regex filter (contains word X)
+ *   - With reference: searches within that book/chapter
+ *   - Without reference: requires resource, searches entire translation (parallel fetch)
  */
 
 import { json } from '@sveltejs/kit';
@@ -23,6 +25,29 @@ import {
 } from '$lib/../../../src/services/SearchServiceFactory.js';
 import { parseReference } from '$lib/referenceParser.js';
 import { generateStemmedPattern } from '$lib/stemmedFilter.js';
+
+// All 66 book codes for full-resource search
+const ALL_BOOKS = [
+	'gen', 'exo', 'lev', 'num', 'deu', 'jos', 'jdg', 'rut', '1sa', '2sa',
+	'1ki', '2ki', '1ch', '2ch', 'ezr', 'neh', 'est', 'job', 'psa', 'pro',
+	'ecc', 'sng', 'isa', 'jer', 'lam', 'ezk', 'dan', 'hos', 'jol', 'amo',
+	'oba', 'jon', 'mic', 'nam', 'hab', 'zep', 'hag', 'zec', 'mal',
+	'mat', 'mrk', 'luk', 'jhn', 'act', 'rom', '1co', '2co', 'gal', 'eph',
+	'php', 'col', '1th', '2th', '1ti', '2ti', 'tit', 'phm', 'heb', 'jas',
+	'1pe', '2pe', '1jn', '2jn', '3jn', 'jud', 'rev'
+];
+const NT_BOOKS = ALL_BOOKS.slice(39);
+const OT_BOOKS = ALL_BOOKS.slice(0, 39);
+
+/**
+ * Extract book name from scripture text (for full-resource search)
+ * Looks for markdown header like "# Genesis" or "# 1 John"
+ */
+function extractBookFromText(text: string): string {
+	const headerMatch = text.match(/^#\s+(.+?)(?:\s+\d+)?$/m);
+	if (headerMatch) return headerMatch[1].trim();
+	return 'Unknown';
+}
 
 /**
  * Parse resource parameter
@@ -129,36 +154,86 @@ async function handleFilterRequest(request: Request): Promise<Response | null> {
 	if (!filter) return null;
 	
 	const reference = url.searchParams.get('reference');
-	if (!reference) {
+	const language = url.searchParams.get('language') || 'en';
+	const organization = url.searchParams.get('organization') || 'unfoldingWord';
+	const resourceParam = url.searchParams.get('resource');
+	const testament = url.searchParams.get('testament')?.toLowerCase();
+	
+	// Validate: need reference OR specific resource (not 'all')
+	if (!reference && (!resourceParam || resourceParam === 'all')) {
 		return json({
-			error: 'Reference is required when using filter parameter',
-			hint: 'Provide a book or chapter reference (e.g., reference=John or reference=Romans 8)'
+			error: 'Filter requires either a reference OR a specific resource',
+			hints: [
+				'With reference: filter=love&reference=John',
+				'With resource: filter=love&resource=ult',
+				'Limit scope: filter=love&resource=ult&testament=nt'
+			],
+			availableResources: ['ult', 'ust', 't4t', 'ueb'],
+			availableTestaments: ['ot', 'nt']
 		}, { status: 400 });
 	}
 	
-	const language = url.searchParams.get('language') || 'en';
-	const organization = url.searchParams.get('organization') || 'unfoldingWord';
-	const resourceParam = url.searchParams.get('resource') || 'all';
+	// For full-resource search, only allow single resource
+	const requestedResources = parseResources(resourceParam || 'ult');
+	if (!reference && requestedResources.length > 1) {
+		return json({
+			error: 'Full-resource search requires a single resource',
+			hints: [
+				'Use one resource: filter=love&resource=ult',
+				'Or add reference: filter=love&reference=John&resource=ult,ust'
+			]
+		}, { status: 400 });
+	}
 	
-	console.log(`[fetch-scripture] Filter: "${filter}" in ${reference}`);
+	console.log(`[fetch-scripture] Filter: "${filter}" in ${reference || `full ${requestedResources[0]}`}`);
 	
 	// Generate stemmed pattern
 	const pattern = generateStemmedPattern(filter);
 	console.log(`[fetch-scripture] Pattern: ${pattern}`);
 	
-	const requestedResources = parseResources(resourceParam);
 	const tracer = new EdgeXRayTracer(`scripture-filter-${Date.now()}`, 'fetch-scripture-filter');
 	const fetcher = new UnifiedResourceFetcher(tracer);
 	fetcher.setRequestHeaders(Object.fromEntries(request.headers.entries()));
 	
-	// Fetch scripture for the reference
-	const results = await fetcher.fetchScripture(reference, language, organization, requestedResources);
+	let results: any[] = [];
+	let booksSearched: string[] = [];
+	
+	if (reference) {
+		// Single reference - simple fetch
+		results = await fetcher.fetchScripture(reference, language, organization, requestedResources);
+	} else {
+		// Full resource search - parallel fetch all books
+		const books = testament === 'nt' ? NT_BOOKS : testament === 'ot' ? OT_BOOKS : ALL_BOOKS;
+		console.log(`[fetch-scripture] Parallel fetching ${books.length} books from ${requestedResources[0]}`);
+		
+		// Fire all fetches in parallel (I/O bound - overlaps nicely)
+		const fetchPromises = books.map(async (bookCode) => {
+			try {
+				const bookResults = await fetcher.fetchScripture(bookCode, language, organization, requestedResources);
+				return { bookCode, results: bookResults || [] };
+			} catch {
+				return { bookCode, results: [] };
+			}
+		});
+		
+		// Gather all results
+		const allBookResults = await Promise.all(fetchPromises);
+		for (const { bookCode, results: bookResults } of allBookResults) {
+			if (bookResults.length > 0) {
+				results.push(...bookResults);
+				booksSearched.push(bookCode);
+			}
+		}
+	}
 	
 	if (!results || results.length === 0) {
 		return json({
-			error: `Scripture not found for reference: ${reference}`,
+			error: reference
+				? `Scripture not found for reference: ${reference}`
+				: `No scripture found for resource: ${resourceParam}`,
 			filter,
-			pattern: pattern.toString()
+			pattern: pattern.toString(),
+			hints: ['Check resource exists: ult, ust, t4t, ueb']
 		}, { status: 404 });
 	}
 	
@@ -171,13 +246,15 @@ async function handleFilterRequest(request: Request): Promise<Response | null> {
 		matchCount: number;
 	}> = [];
 	
-	const parsedRef = parseReference(reference);
-	// Extract just the book name, not the chapter
-	const book = parsedRef?.book || reference.replace(/\s+\d+.*$/, '').trim();
-	const chapter = parsedRef?.chapter;
+	// For single reference, use parsed book/chapter; for full resource, extract from each result
+	const parsedRef = reference ? parseReference(reference) : null;
+	const singleBook = parsedRef?.book || (reference ? reference.replace(/\s+\d+.*$/, '').trim() : null);
+	const singleChapter = parsedRef?.chapter;
 	
 	for (const result of results) {
-		const verses = parseIntoVerses(result.text, book, result.translation, chapter);
+		// For full-resource, extract book from result; for single ref, use parsed book
+		const book = singleBook || extractBookFromText(result.text);
+		const verses = parseIntoVerses(result.text, book, result.translation, singleChapter);
 		
 		for (const verse of verses) {
 			pattern.lastIndex = 0;
@@ -199,16 +276,28 @@ async function handleFilterRequest(request: Request): Promise<Response | null> {
 		}
 	}
 	
-	return json({
+	const response: Record<string, any> = {
 		filter,
 		pattern: pattern.toString(),
-		reference,
 		language,
 		organization,
+		resource: requestedResources.join(','),
 		totalMatches: matches.length,
 		matches,
 		_trace: tracer.getTrace()
-	});
+	};
+	
+	if (reference) {
+		response.reference = reference;
+	} else {
+		response.searchScope = {
+			testament: testament || 'all',
+			booksSearched: booksSearched.length,
+			books: booksSearched
+		};
+	}
+	
+	return json(response);
 }
 
 /**

--- a/ui/src/routes/api/fetch-scripture/+server.ts
+++ b/ui/src/routes/api/fetch-scripture/+server.ts
@@ -44,7 +44,8 @@ const OT_BOOKS = ALL_BOOKS.slice(0, 39);
  * Looks for markdown header like "# Genesis" or "# 1 John"
  */
 function extractBookFromText(text: string): string {
-	const headerMatch = text.match(/^#\s+(.+?)(?:\s+\d+)?$/m);
+	// Match "# BookName" at start of line (before any chapter headers)
+	const headerMatch = text.match(/^#\s+([A-Za-z0-9\s]+?)\s*$/m);
 	if (headerMatch) return headerMatch[1].trim();
 	return 'Unknown';
 }

--- a/ui/src/routes/api/fetch-scripture/+server.ts
+++ b/ui/src/routes/api/fetch-scripture/+server.ts
@@ -6,8 +6,7 @@
  * 
  * Parameters:
  * - search: AutoRAG semantic search (conceptually about X)
- * - filter: Stemmed regex filter (contains word X)
- * - stream: Enable NDJSON streaming for filter results
+ * - filter: Stemmed regex filter (contains word X) - requires reference
  */
 
 import { json } from '@sveltejs/kit';
@@ -23,207 +22,159 @@ import {
 	type SearchDocument
 } from '$lib/../../../src/services/SearchServiceFactory.js';
 import { parseReference } from '$lib/referenceParser.js';
-import {
-	generateStemmedPattern,
-	parseScriptureIntoVerses,
-	createNDJSONStream,
-	getStreamingHeaders,
-	type FilterMatch
-} from '$lib/stemmedFilter.js';
+import { generateStemmedPattern } from '$lib/stemmedFilter.js';
 
 /**
  * Parse resource parameter
- * Supports both standard types (ult, ust, t4t, ueb) and gateway equivalents (glt, gst)
  */
 function parseResources(resourceParam: string | undefined): string[] {
-	// Include gateway equivalents: glt (equivalent to ult), gst (equivalent to ust)
 	const availableResources = ['ult', 'ust', 't4t', 'ueb', 'glt', 'gst'];
 
 	if (!resourceParam || resourceParam === 'all') {
-		// Return unique resources (don't include both ult/glt and ust/gst)
 		return ['ult', 'ust', 't4t', 'ueb'];
 	}
 
-	// Handle comma-separated resources
 	const requested = resourceParam
 		.split(',')
 		.map((r) => r.trim())
 		.filter((r) => availableResources.includes(r));
 
-	// Remove duplicates (e.g., if both ult and glt are requested)
 	const unique = new Set<string>();
 	for (const r of requested) {
-		// Map gateway resources to their equivalents
-		if (r === 'glt') {
-			unique.add('ult');
-		} else if (r === 'gst') {
-			unique.add('ust');
-		} else {
-			unique.add(r);
-		}
+		if (r === 'glt') unique.add('ult');
+		else if (r === 'gst') unique.add('ust');
+		else unique.add(r);
 	}
 
 	return Array.from(unique);
 }
 
 /**
- * Parse USFM text into individual verses with references
- * Used when searching book-only references to return individual verses instead of entire book
+ * Parse text into individual verses
  */
-function parseUSFMIntoVerses(
-	usfmText: string,
+function parseIntoVerses(
+	text: string,
 	book: string,
 	translation: string
-): Array<{ text: string; reference: string; translation: string }> {
-	const verses: Array<{ text: string; reference: string; translation: string }> = [];
-
-	// Split by chapter markers or verse markers
-	// Look for patterns like "## Chapter X" or verse numbers
-	const lines = usfmText.split(/\n+/);
+): Array<{ text: string; reference: string; chapter: number; verse: number; translation: string }> {
+	const verses: Array<{ text: string; reference: string; chapter: number; verse: number; translation: string }> = [];
+	const lines = text.split('\n');
 	let currentChapter = 0;
-	let currentVerse = 0;
-	let verseText = '';
 
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i].trim();
-
-		// Detect chapter markers (from extractFullBookFromUSFM output)
-		const chapterMatch = line.match(/^##\s+Chapter\s+(\d+)/i);
+	for (const line of lines) {
+		// Chapter header: "## Chapter 3" or "# Book Chapter 3"
+		const chapterMatch = line.match(/^#+ .*?Chapter\s+(\d+)/i) || line.match(/^##\s+Chapter\s+(\d+)/i);
 		if (chapterMatch) {
-			// Save previous verse if exists
-			if (currentVerse > 0 && verseText.trim()) {
-				verses.push({
-					text: verseText.trim(),
-					reference: `${book} ${currentChapter}:${currentVerse}`,
-					translation
-				});
-				verseText = '';
-			}
 			currentChapter = parseInt(chapterMatch[1], 10);
-			currentVerse = 0;
 			continue;
 		}
 
-		// Detect verse markers (from extractFullBookFromUSFM output or raw USFM)
-		// Match patterns like "[[VERSE:1]]", "1. text", or "1 text" (no period)
-		const verseMatch = line.match(/\[\[VERSE:(\d+)\]\]|^(\d+)[.\s]\s*/);
+		// Verse line: "3:16 For God so loved..."
+		const verseMatch = line.match(/^(\d+):(\d+)\s+(.+)$/);
 		if (verseMatch) {
-			// Save previous verse if exists
-			if (currentVerse > 0 && verseText.trim()) {
-				verses.push({
-					text: verseText.trim(),
-					reference: `${book} ${currentChapter}:${currentVerse}`,
-					translation
-				});
-			}
-			currentVerse = parseInt(verseMatch[1] || verseMatch[2], 10);
-			verseText = line.replace(/\[\[VERSE:\d+\]\]|^\d+[.\s]\s*/, '').trim();
-			continue;
+			const [, chapter, verse, verseText] = verseMatch;
+			currentChapter = parseInt(chapter, 10);
+			verses.push({
+				text: verseText.trim(),
+				reference: `${book} ${chapter}:${verse}`,
+				chapter: parseInt(chapter, 10),
+				verse: parseInt(verse, 10),
+				translation
+			});
 		}
-
-		// Continue collecting verse text
-		if (currentChapter > 0 && currentVerse > 0 && line) {
-			// Skip chapter headers and other metadata
-			if (!line.startsWith('##') && !line.startsWith('[')) {
-				verseText += (verseText ? ' ' : '') + line;
-			}
-		}
-	}
-
-	// Don't forget the last verse
-	if (currentChapter > 0 && currentVerse > 0 && verseText.trim()) {
-		verses.push({
-			text: verseText.trim(),
-			reference: `${book} ${currentChapter}:${currentVerse}`,
-			translation
-		});
-	}
-
-	// If no verses found using the formatted approach, try parsing raw USFM
-	if (verses.length === 0 && usfmText.includes('\\c ') && usfmText.includes('\\v ')) {
-		return parseRawUSFMIntoVerses(usfmText, book, translation);
 	}
 
 	return verses;
 }
 
 /**
- * Parse raw USFM format into individual verses
+ * Handle filter requests - stemmed regex matching
  */
-function parseRawUSFMIntoVerses(
-	usfmText: string,
-	book: string,
-	translation: string
-): Array<{ text: string; reference: string; translation: string }> {
-	const verses: Array<{ text: string; reference: string; translation: string }> = [];
-	const lines = usfmText.split('\n');
-	let currentChapter = 0;
-	let currentVerse = 0;
-	let verseText = '';
-
-	for (const line of lines) {
-		// Chapter marker: \c 3
-		const chapterMatch = line.match(/\\c\s+(\d+)/);
-		if (chapterMatch) {
-			// Save previous verse
-			if (currentVerse > 0 && verseText.trim()) {
-				verses.push({
-					text: verseText.trim(),
-					reference: `${book} ${currentChapter}:${currentVerse}`,
-					translation
-				});
-				verseText = '';
+async function handleFilterRequest(request: Request): Promise<Response | null> {
+	const url = new URL(request.url);
+	const filter = url.searchParams.get('filter');
+	
+	if (!filter) return null;
+	
+	const reference = url.searchParams.get('reference');
+	if (!reference) {
+		return json({
+			error: 'Reference is required when using filter parameter',
+			hint: 'Provide a book or chapter reference (e.g., reference=John or reference=Romans 8)'
+		}, { status: 400 });
+	}
+	
+	const language = url.searchParams.get('language') || 'en';
+	const organization = url.searchParams.get('organization') || 'unfoldingWord';
+	const resourceParam = url.searchParams.get('resource') || 'all';
+	
+	console.log(`[fetch-scripture] Filter: "${filter}" in ${reference}`);
+	
+	// Generate stemmed pattern
+	const pattern = generateStemmedPattern(filter);
+	console.log(`[fetch-scripture] Pattern: ${pattern}`);
+	
+	const requestedResources = parseResources(resourceParam);
+	const tracer = new EdgeXRayTracer(`scripture-filter-${Date.now()}`, 'fetch-scripture-filter');
+	const fetcher = new UnifiedResourceFetcher(tracer);
+	fetcher.setRequestHeaders(Object.fromEntries(request.headers.entries()));
+	
+	// Fetch scripture for the reference
+	const results = await fetcher.fetchScripture(reference, language, organization, requestedResources);
+	
+	if (!results || results.length === 0) {
+		return json({
+			error: `Scripture not found for reference: ${reference}`,
+			filter,
+			pattern: pattern.toString()
+		}, { status: 404 });
+	}
+	
+	// Parse into verses and filter
+	const matches: Array<{
+		reference: string;
+		text: string;
+		resource: string;
+		matchedTerms: string[];
+		matchCount: number;
+	}> = [];
+	
+	const parsedRef = parseReference(reference);
+	const book = parsedRef?.book || reference.split(' ')[0];
+	
+	for (const result of results) {
+		const verses = parseIntoVerses(result.text, book, result.translation);
+		
+		for (const verse of verses) {
+			pattern.lastIndex = 0;
+			const found: string[] = [];
+			let match;
+			while ((match = pattern.exec(verse.text)) !== null) {
+				found.push(match[0]);
 			}
-			currentChapter = parseInt(chapterMatch[1], 10);
-			currentVerse = 0;
-			continue;
-		}
-
-		// Verse marker: \v 16
-		const verseMatch = line.match(/\\v\s+(\d+)\s*(.*)/);
-		if (verseMatch) {
-			// Save previous verse
-			if (currentVerse > 0 && verseText.trim()) {
-				verses.push({
-					text: verseText.trim(),
-					reference: `${book} ${currentChapter}:${currentVerse}`,
-					translation
+			
+			if (found.length > 0) {
+				matches.push({
+					reference: verse.reference,
+					text: verse.text,
+					resource: result.translation,
+					matchedTerms: [...new Set(found)],
+					matchCount: found.length
 				});
-			}
-			currentVerse = parseInt(verseMatch[1], 10);
-			// Clean USFM markers from verse text
-			verseText = verseMatch[2]
-				.replace(/\\w\s+[^|]+\|[^\\]+\\w\*/g, '') // Word markers
-				.replace(/\\zaln-[se]\|[^\\]+\\*/g, '') // Alignment markers
-				.replace(/\\[a-z]+\d*\s*/g, '') // Other markers
-				.replace(/\s+/g, ' ')
-				.trim();
-			continue;
-		}
-
-		// Continue verse text (non-marker lines)
-		if (currentChapter > 0 && currentVerse > 0 && line.trim() && !line.match(/^\\[a-z]/)) {
-			const cleaned = line
-				.replace(/\\w\s+[^|]+\|[^\\]+\\w\*/g, '')
-				.replace(/\\zaln-[se]\|[^\\]+\\*/g, '')
-				.replace(/\\[a-z]+\d*\s*/g, '')
-				.trim();
-			if (cleaned) {
-				verseText += (verseText ? ' ' : '') + cleaned;
 			}
 		}
 	}
-
-	// Save last verse
-	if (currentChapter > 0 && currentVerse > 0 && verseText.trim()) {
-		verses.push({
-			text: verseText.trim(),
-			reference: `${book} ${currentChapter}:${currentVerse}`,
-			translation
-		});
-	}
-
-	return verses;
+	
+	return json({
+		filter,
+		pattern: pattern.toString(),
+		reference,
+		language,
+		organization,
+		totalMatches: matches.length,
+		matches,
+		_trace: tracer.getTrace()
+	});
 }
 
 /**
@@ -232,73 +183,48 @@ function parseRawUSFMIntoVerses(
 async function fetchScripture(params: Record<string, any>, request: Request): Promise<any> {
 	const { reference, language, organization, resource: resourceParam, search } = params;
 
-	// Create tracer and fetcher FIRST - needed by all code paths
 	const tracer = new EdgeXRayTracer(`scripture-${Date.now()}`, 'fetch-scripture');
 	const fetcher = new UnifiedResourceFetcher(tracer);
 	fetcher.setRequestHeaders(Object.fromEntries(request.headers.entries()));
 
-	// Get requested resources
 	const requestedResources = parseResources(resourceParam);
 
-	// If no reference but has search, delegate to /api/search (DRY - uses cached indexes)
+	// If no reference but has search, delegate to /api/search
 	if (!reference && search) {
-		console.log(
-			'[fetch-scripture-v2] No reference provided, delegating to /api/search for:',
-			search
-		);
+		console.log('[fetch-scripture-v2] No reference, delegating to /api/search:', search);
 
 		const startTime = Date.now();
-
-		// Build the search URL - use internal fetch to the search endpoint
 		const searchUrl = new URL('/api/search', request.url);
 		searchUrl.searchParams.set('query', search);
 		searchUrl.searchParams.set('language', language || 'en');
 		searchUrl.searchParams.set('organization', organization || 'unfoldingWord');
-		// Request scripture specifically - triggers expanded result fetching in search endpoint
 		searchUrl.searchParams.set('resource', 'scripture');
-		// Also set includeHelps=false as backup filter
 		searchUrl.searchParams.set('includeHelps', 'false');
-		// Request more results since we're filtering client-side too
 		searchUrl.searchParams.set('limit', '50');
 
 		try {
-			// Call the search endpoint internally (shares cached indexes!)
-			const searchResponse = await fetch(searchUrl.toString(), {
-				headers: request.headers
-			});
-
-			if (!searchResponse.ok) {
-				throw new Error(`Search endpoint returned ${searchResponse.status}`);
-			}
+			const searchResponse = await fetch(searchUrl.toString(), { headers: request.headers });
+			if (!searchResponse.ok) throw new Error(`Search returned ${searchResponse.status}`);
 
 			const searchData = await searchResponse.json();
 			const totalTime = Date.now() - startTime;
 
-			console.log(
-				`[fetch-scripture-v2] Search via /api/search complete in ${totalTime}ms: ${searchData.hits?.length || 0} hits`
-			);
-
-		// Transform search results to scripture format
-		// Filter to scripture resources AND the requested language
-		const SCRIPTURE_RESOURCES = ['ult', 'ust', 'ueb', 't4t', 'scripture', 'glt', 'gst'];
-		const requestedLang = (language || 'en').toLowerCase();
-		const scriptureResults = (searchData.hits || [])
-			.filter((hit: any) => {
-				const resource = (hit.resource || '').toLowerCase();
-				const hitLang = (hit.language || '').toLowerCase();
-				// Must be scripture resource AND match requested language
-				const isScripture = SCRIPTURE_RESOURCES.includes(resource);
-				const matchesLanguage = !hitLang || hitLang === requestedLang;
-				return isScripture && matchesLanguage;
-			})
-			.map((hit: any) => ({
-				text: hit.preview?.replace(/\*\*/g, '') || hit.content || '',
-				reference: hit.reference || hit.path || '',
-				translation: hit.resource || '',
-				language: hit.language || language || 'en',
-				searchScore: hit.score,
-				matchedTerms: hit.match?.terms
-			}));
+			const SCRIPTURE_RESOURCES = ['ult', 'ust', 'ueb', 't4t', 'scripture', 'glt', 'gst'];
+			const requestedLang = (language || 'en').toLowerCase();
+			
+			const scriptureResults = (searchData.hits || [])
+				.filter((hit: any) => {
+					const resource = (hit.resource || '').toLowerCase();
+					const hitLang = (hit.language || '').toLowerCase();
+					return SCRIPTURE_RESOURCES.includes(resource) && (!hitLang || hitLang === requestedLang);
+				})
+				.map((hit: any) => ({
+					text: hit.preview?.replace(/\*\*/g, '') || hit.content || '',
+					reference: hit.reference || hit.path || '',
+					translation: hit.resource || '',
+					language: hit.language || language || 'en',
+					searchScore: hit.score
+				}));
 
 			return {
 				scripture: scriptureResults,
@@ -310,144 +236,55 @@ async function fetchScripture(params: Record<string, any>, request: Request): Pr
 					searchQuery: search,
 					searchApplied: true,
 					searchTime: totalTime,
-					delegatedTo: '/api/search',
-					resourcesSearched: searchData.resourceCount || 0
+					delegatedTo: '/api/search'
 				}
 			};
 		} catch (error) {
-			console.error('[fetch-scripture-v2] Failed to delegate to /api/search:', error);
 			throw new Error(`Search failed: ${error instanceof Error ? error.message : String(error)}`);
 		}
 	}
 
-	// Require reference if not searching
 	if (!reference && !search) {
 		throw new Error('Reference is required when not searching');
 	}
 
-	// Parse reference to check if it's book-only or chapter-only
-	const parsedRef = parseReference(reference);
-	const isBookOnly = parsedRef && !parsedRef.chapter;
-	const isChapterOnly = parsedRef && parsedRef.chapter && !parsedRef.verse;
-
-	// Fetch using unified fetcher
+	// Fetch scripture
 	let results = await fetcher.fetchScripture(reference, language, organization, requestedResources);
 
 	if (!results || results.length === 0) {
 		throw new Error(`Scripture not found for reference: ${reference}`);
 	}
 
-	// Apply search if query provided (ephemeral, in-memory only)
+	// Apply search if provided
 	if (search && search.trim().length > 0) {
-		const totalBeforeSearch = results.length;
-
-		// If book-only or chapter-only reference, parse into individual verses first
-		if ((isBookOnly || isChapterOnly) && parsedRef) {
-			const parsedVerses: Array<{ text: string; reference: string; translation: string }> = [];
-
-			// Parse each translation's text into individual verses
-			for (const result of results) {
-				// For chapter-only references, the text is already pre-formatted
-				// but we still need to parse it into individual verses
-				if (isChapterOnly) {
-					// Parse the chapter text into verses
-					const lines = result.text.split(/\n+/);
-					let currentVerse = 0;
-					let verseText = '';
-
-					for (const line of lines) {
-						// Check for verse number at start of line (format: "16 text...")
-						const verseMatch = line.match(/^(\d+)\s+(.+)/);
-						if (verseMatch) {
-							// Save previous verse if exists
-							if (currentVerse > 0 && verseText.trim()) {
-								// Clean up trailing backslashes and whitespace
-								const cleanText = verseText.replace(/\\+\s*$/, '').trim();
-								if (cleanText) {
-									parsedVerses.push({
-										text: cleanText,
-										reference: `${parsedRef.book} ${parsedRef.chapter}:${currentVerse}`,
-										translation: result.translation
-									});
-								}
-							}
-							currentVerse = parseInt(verseMatch[1], 10);
-							verseText = verseMatch[2];
-						} else if (currentVerse > 0 && line.trim()) {
-							// Continue current verse text
-							verseText += ' ' + line.trim();
-						}
-					}
-
-					// Don't forget the last verse
-					if (currentVerse > 0 && verseText.trim()) {
-						// Clean up trailing backslashes and whitespace
-						const cleanText = verseText.replace(/\\+\s*$/, '').trim();
-						if (cleanText) {
-							parsedVerses.push({
-								text: cleanText,
-								reference: `${parsedRef.book} ${parsedRef.chapter}:${currentVerse}`,
-								translation: result.translation
-							});
-						}
-					}
-				} else {
-					// Book-only reference - use existing parser
-					const verses = parseUSFMIntoVerses(result.text, parsedRef.book, result.translation);
-					parsedVerses.push(...verses);
-				}
+		const parsedRef = parseReference(reference);
+		const book = parsedRef?.book || reference;
+		
+		const parsedVerses: Array<{ text: string; reference: string; translation: string }> = [];
+		for (const result of results) {
+			const verses = parseIntoVerses(result.text, book, result.translation);
+			for (const v of verses) {
+				parsedVerses.push({ text: v.text, reference: v.reference, translation: v.translation });
 			}
+		}
 
-			if (parsedVerses.length === 0) {
-				console.error(`[fetch-scripture-v2] No verses parsed from content!`, {
-					reference,
-					resultsCount: results.length
-				});
-				// Return empty results if no verses parsed
-				results = [];
-			} else {
-				// Now search the individual verses
-				results = await applySearch(
-					parsedVerses,
-					search,
-					'scripture',
-					(item: any, index: number): SearchDocument => ({
-						id: `${item.translation}-${item.reference}-${index}`,
-						content: item.text,
-						path: item.reference,
-						resource: item.translation,
-						type: 'bible'
-					})
-				);
-			}
-		} else {
-			// Normal search for specific verse references (e.g., John 3:16)
+		if (parsedVerses.length > 0) {
 			results = await applySearch(
-				results,
+				parsedVerses,
 				search,
 				'scripture',
 				(item: any, index: number): SearchDocument => ({
-					id: `${item.translation}-${item.reference || reference}-${index}`,
+					id: `${item.translation}-${item.reference}-${index}`,
 					content: item.text,
-					path: item.reference || reference,
+					path: item.reference,
 					resource: item.translation,
 					type: 'bible'
 				})
 			);
 		}
-
-		console.log(
-			`[fetch-scripture-v2] Search "${search}" filtered ${totalBeforeSearch} results to ${results.length}`
-		);
-	} else {
-		// Log for debugging - verify all versions are being returned
-		console.log(
-			`[fetch-scripture-v2] Fetched ${results.length} scripture versions:`,
-			results.map((s: any) => s.translation || 'Unknown')
-		);
 	}
 
-	// Deduplicate results by translation + reference combination
+	// Deduplicate
 	const uniqueResults = results.reduce((acc: any[], curr: any) => {
 		const key = `${curr.translation}-${curr.reference || reference}`;
 		if (!acc.some((r) => `${r.translation}-${r.reference || reference}` === key)) {
@@ -456,281 +293,53 @@ async function fetchScripture(params: Record<string, any>, request: Request): Pr
 		return acc;
 	}, []);
 
-	// Return in standard format with trace data
 	const baseResponse = createScriptureResponse(uniqueResults, {
 		reference,
 		requestedResources,
-		foundResources: [
-			...new Set(uniqueResults.map((s: any) => s.translation?.split(' ')[0]?.toLowerCase()))
-		]
+		foundResources: [...new Set(uniqueResults.map((s: any) => s.translation?.split(' ')[0]?.toLowerCase()))]
 	});
 
-	// Add search metadata if search was applied
-	const response = {
+	return {
 		...baseResponse,
-		metadata: search
-			? addSearchMetadata(baseResponse.metadata, search, results.length)
-			: baseResponse.metadata,
+		metadata: search ? addSearchMetadata(baseResponse.metadata, search, results.length) : baseResponse.metadata,
 		_trace: fetcher.getTrace()
 	};
-
-	// Log the response structure to verify all scriptures are included
-	console.log(
-		`[fetch-scripture-v2] Response contains ${response.scripture?.length || 0} scriptures in response.scripture array`
-	);
-
-	return response;
 }
 
 /**
- * Handle streaming filter requests
- * When filter param is provided with stream=true, bypass normal endpoint
- * and stream results as NDJSON
+ * GET handler - check for filter first, then normal endpoint
  */
-async function handleStreamingFilter(request: Request): Promise<Response | null> {
-	const url = new URL(request.url);
-	const filter = url.searchParams.get('filter');
-	const stream = url.searchParams.get('stream') === 'true';
-	
-	// Only handle if filter is provided
-	if (!filter) return null;
-	
-	const language = url.searchParams.get('language') || 'en';
-	const organization = url.searchParams.get('organization') || 'unfoldingWord';
-	const resourceParam = url.searchParams.get('resource') || 'all';
-	const reference = url.searchParams.get('reference');
-	
-	console.log(`[fetch-scripture] Filter request: "${filter}", stream=${stream}, ref=${reference || 'all'}`);
-	
-	// Generate stemmed pattern
-	const pattern = generateStemmedPattern(filter);
-	console.log(`[fetch-scripture] Stemmed pattern: ${pattern}`);
-	
-	// Get requested resources
-	const requestedResources = parseResources(resourceParam);
-	
-	// Create tracer and fetcher
-	const tracer = new EdgeXRayTracer(`scripture-filter-${Date.now()}`, 'fetch-scripture-filter');
-	const fetcher = new UnifiedResourceFetcher(tracer);
-	fetcher.setRequestHeaders(Object.fromEntries(request.headers.entries()));
-	
-	if (stream) {
-		// Streaming mode - return results as they're found
-		const { stream: responseStream, writer } = createNDJSONStream();
-		
-		// Process in background
-		(async () => {
-			try {
-				let totalMatches = 0;
-				
-				// If reference provided, fetch just that. Otherwise fetch all books.
-				if (reference) {
-					const results = await fetcher.fetchScripture(reference, language, organization, requestedResources);
-					
-					for (const result of results) {
-						const verses = parseScriptureIntoVerses(
-							result.text,
-							result.reference || reference,
-							result.translation,
-							language
-						);
-						
-						for (const verse of verses) {
-							pattern.lastIndex = 0;
-							const matches: string[] = [];
-							let match;
-							while ((match = pattern.exec(verse.text)) !== null) {
-								matches.push(match[0]);
-							}
-							
-							if (matches.length > 0) {
-								totalMatches++;
-								writer.write({
-									reference: verse.reference,
-									text: verse.text,
-									resource: result.translation,
-									language,
-									matchedTerms: [...new Set(matches)],
-									matchCount: matches.length
-								});
-							}
-						}
-					}
-				} else {
-					// Fetch all books - this is comprehensive but slower
-					// Get list of all books
-					const allBooks = [
-						'GEN', 'EXO', 'LEV', 'NUM', 'DEU', 'JOS', 'JDG', 'RUT', '1SA', '2SA',
-						'1KI', '2KI', '1CH', '2CH', 'EZR', 'NEH', 'EST', 'JOB', 'PSA', 'PRO',
-						'ECC', 'SNG', 'ISA', 'JER', 'LAM', 'EZK', 'DAN', 'HOS', 'JOL', 'AMO',
-						'OBA', 'JON', 'MIC', 'NAM', 'HAB', 'ZEP', 'HAG', 'ZEC', 'MAL',
-						'MAT', 'MRK', 'LUK', 'JHN', 'ACT', 'ROM', '1CO', '2CO', 'GAL', 'EPH',
-						'PHP', 'COL', '1TH', '2TH', '1TI', '2TI', 'TIT', 'PHM', 'HEB', 'JAS',
-						'1PE', '2PE', '1JN', '2JN', '3JN', 'JUD', 'REV'
-					];
-					
-					for (const book of allBooks) {
-						try {
-							const results = await fetcher.fetchScripture(book, language, organization, requestedResources);
-							
-							for (const result of results) {
-								const verses = parseScriptureIntoVerses(
-									result.text,
-									book,
-									result.translation,
-									language
-								);
-								
-								for (const verse of verses) {
-									pattern.lastIndex = 0;
-									const matches: string[] = [];
-									let match;
-									while ((match = pattern.exec(verse.text)) !== null) {
-										matches.push(match[0]);
-									}
-									
-									if (matches.length > 0) {
-										totalMatches++;
-										writer.write({
-											reference: verse.reference,
-											text: verse.text,
-											resource: result.translation,
-											language,
-											matchedTerms: [...new Set(matches)],
-											matchCount: matches.length
-										});
-									}
-								}
-							}
-						} catch (err) {
-							// Skip books that fail (might not exist in this translation)
-							console.log(`[fetch-scripture] Skipping ${book}: ${err}`);
-						}
-					}
-				}
-				
-				// Write final summary
-				writer.write({
-					_summary: true,
-					totalMatches,
-					filter,
-					pattern: pattern.toString()
-				});
-				
-			} catch (err) {
-				writer.write({ error: err instanceof Error ? err.message : String(err) });
-			} finally {
-				writer.close();
-			}
-		})();
-		
-		return new Response(responseStream, {
-			headers: getStreamingHeaders()
-		});
-	} else {
-		// Non-streaming mode - collect all results then return
-		const allMatches: FilterMatch[] = [];
-		
-		if (reference) {
-			const results = await fetcher.fetchScripture(reference, language, organization, requestedResources);
-			
-			for (const result of results) {
-				const verses = parseScriptureIntoVerses(
-					result.text,
-					result.reference || reference,
-					result.translation,
-					language
-				);
-				
-				for (const verse of verses) {
-					pattern.lastIndex = 0;
-					const matches: string[] = [];
-					let match;
-					while ((match = pattern.exec(verse.text)) !== null) {
-						matches.push(match[0]);
-					}
-					
-					if (matches.length > 0) {
-						allMatches.push({
-							reference: verse.reference,
-							text: verse.text,
-							resource: result.translation,
-							language,
-							matchedTerms: [...new Set(matches)],
-							matchCount: matches.length
-						});
-					}
-				}
-			}
-		} else {
-			// Without reference, require stream=true for comprehensive search
-			return json({
-				error: 'Reference required for non-streaming filter. Use stream=true for comprehensive search.',
-				hint: 'Add stream=true to search all scripture, or provide a reference (e.g., reference=John)'
-			}, { status: 400 });
-		}
-		
-		return json({
-			filter,
-			pattern: pattern.toString(),
-			language,
-			organization,
-			totalMatches: allMatches.length,
-			matches: allMatches,
-			_trace: tracer.getTrace()
-		});
-	}
-}
-
-/**
- * Main GET handler - checks for filter requests first, then falls through to normal endpoint
- */
-const filterHandler: RequestHandler = async ({ request }) => {
-	const filterResponse = await handleStreamingFilter(request);
+export const GET: RequestHandler = async (event) => {
+	// Check for filter param first
+	const filterResponse = await handleFilterRequest(event.request);
 	if (filterResponse) return filterResponse;
 	
-	// Fall through to normal endpoint (handled by createSimpleEndpoint below)
-	return null as any; // TypeScript workaround - we'll chain handlers
+	// Otherwise use normal endpoint
+	return normalEndpoint(event);
 };
 
-// Create the endpoint with format support
+// Normal endpoint (used when no filter param)
 const normalEndpoint = createSimpleEndpoint({
 	name: 'fetch-scripture-v2',
-
 	params: [
-		{
-			name: 'reference',
-			required: false, // Optional when search is provided
-			validate: isValidReference
-		},
+		{ name: 'reference', required: false, validate: isValidReference },
 		COMMON_PARAMS.language,
 		COMMON_PARAMS.organization,
 		{
 			name: 'resource',
 			default: 'all',
 			validate: (value) => {
-				if (!value) return true;
-				if (value === 'all') return true;
-				const resources = value.split(',').map((r) => r.trim());
-				// Include gateway equivalents: glt (equivalent to ult), gst (equivalent to ust)
-				return resources.every((r) => ['ult', 'ust', 't4t', 'ueb', 'glt', 'gst'].includes(r));
+				if (!value || value === 'all') return true;
+				return value.split(',').every((r) => ['ult', 'ust', 't4t', 'ueb', 'glt', 'gst'].includes(r.trim()));
 			}
 		},
-		COMMON_PARAMS.search // Add optional search parameter
+		COMMON_PARAMS.search
 	],
-
-	// Enable format support - format parameter will be added automatically
 	supportsFormats: true,
-
 	fetch: fetchScripture,
-
 	onError: createStandardErrorHandler({
-		'Scripture not found for reference': {
-			status: 404,
-			message: 'No scripture available for the specified reference.'
-		}
+		'Scripture not found for reference': { status: 404, message: 'No scripture available for the specified reference.' }
 	})
 });
 
-// CORS handler
 export const OPTIONS = createCORSHandler();

--- a/ui/src/routes/api/fetch-scripture/+server.ts
+++ b/ui/src/routes/api/fetch-scripture/+server.ts
@@ -294,15 +294,11 @@ async function handleFilterRequest(request: Request, r2Bucket?: any): Promise<Re
 				// Find a .usfm file to extract the base path from
 				// e.g., "by-url/git.door43.org/unfoldingWord/en_ult/archive/v87.zip/files/41-MAT.usfm"
 				const usfmFile = listResult.objects.find(obj => obj.key.endsWith('.usfm'));
-				if (!usfmFile) {
-					console.log('[fetch-scripture] No USFM files found in R2 list');
-					fetchMethod = 'per-book-fallback';
-				}
-				
 				const samplePath = usfmFile?.key || '';
 				const archiveMatch = samplePath.match(/^(by-url\/[^/]+\/[^/]+\/[^/]+\/archive\/[^/]+\.zip\/files\/)/);
 				
 				if (archiveMatch && usfmFile) {
+					// R2 direct path found!
 					const basePath = archiveMatch[1];
 					console.log(`[fetch-scripture] R2 base path: ${basePath}`);
 					

--- a/ui/src/routes/api/fetch-scripture/+server.ts
+++ b/ui/src/routes/api/fetch-scripture/+server.ts
@@ -266,17 +266,23 @@ async function fetchScripture(params: Record<string, any>, request: Request): Pr
 			);
 
 		// Transform search results to scripture format
-		// Filter to scripture resources (ult, ust, ueb, t4t, or 'scripture' type)
+		// Filter to scripture resources AND the requested language
 		const SCRIPTURE_RESOURCES = ['ult', 'ust', 'ueb', 't4t', 'scripture', 'glt', 'gst'];
+		const requestedLang = (language || 'en').toLowerCase();
 		const scriptureResults = (searchData.hits || [])
 			.filter((hit: any) => {
 				const resource = (hit.resource || '').toLowerCase();
-				return SCRIPTURE_RESOURCES.includes(resource);
+				const hitLang = (hit.language || '').toLowerCase();
+				// Must be scripture resource AND match requested language
+				const isScripture = SCRIPTURE_RESOURCES.includes(resource);
+				const matchesLanguage = !hitLang || hitLang === requestedLang;
+				return isScripture && matchesLanguage;
 			})
 			.map((hit: any) => ({
 				text: hit.preview?.replace(/\*\*/g, '') || hit.content || '',
 				reference: hit.reference || hit.path || '',
 				translation: hit.resource || '',
+				language: hit.language || language || 'en',
 				searchScore: hit.score,
 				matchedTerms: hit.match?.terms
 			}));

--- a/ui/src/routes/api/fetch-scripture/+server.ts
+++ b/ui/src/routes/api/fetch-scripture/+server.ts
@@ -104,7 +104,8 @@ function parseIntoVerses(
 		}
 
 		// Verse line with just verse number: "16 For God so loved..."
-		const verseOnlyMatch = trimmedLine.match(/^(\d+)\s+(.+)$/);
+		// Also handles: "[ULT v87...] 1 Beloved..." (translation prefix)
+		const verseOnlyMatch = trimmedLine.match(/^(?:\[[^\]]+\]\s*)?(\d+)\s+(.+)$/);
 		if (verseOnlyMatch && currentChapter > 0) {
 			const [, verse, verseText] = verseOnlyMatch;
 			// Skip if this looks like a chapter header (very short)

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.15';
+const BUILD_VERSION = '7.19.16';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.16';
+const BUILD_VERSION = '7.19.17';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.28';
+const BUILD_VERSION = '7.19.29';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.17';
+const BUILD_VERSION = '7.19.18';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.19';
+const BUILD_VERSION = '7.19.20';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.13';
+const BUILD_VERSION = '7.19.14';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.23';
+const BUILD_VERSION = '7.19.24';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.8';
+const BUILD_VERSION = '7.19.10';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.10';
+const BUILD_VERSION = '7.19.12';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.26';
+const BUILD_VERSION = '7.19.28';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.21';
+const BUILD_VERSION = '7.19.22';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.12';
+const BUILD_VERSION = '7.19.13';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.25';
+const BUILD_VERSION = '7.19.26';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.14';
+const BUILD_VERSION = '7.19.15';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.24';
+const BUILD_VERSION = '7.19.25';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.18';
+const BUILD_VERSION = '7.19.19';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.20';
+const BUILD_VERSION = '7.19.21';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.19.22';
+const BUILD_VERSION = '7.19.23';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {

--- a/ui/src/routes/api/search/+server.ts
+++ b/ui/src/routes/api/search/+server.ts
@@ -652,70 +652,72 @@ async function executeSearch(
 		// Scripture resource aliases
 		const SCRIPTURE_RESOURCES = ['ult', 'ust', 'ueb', 't4t', 'scripture'];
 
-		// Resource filter - check if AutoRAG honored it
+		// Resource filter - only filter if hit has resource AND it doesn't match
 		if (resource) {
 			const beforeResourceFilter = hits.length;
 			if (resource === 'scripture' || resource === 'bible') {
-				hits = hits.filter((hit) => SCRIPTURE_RESOURCES.includes(hit.resource));
+				hits = hits.filter((hit) => !hit.resource || SCRIPTURE_RESOURCES.includes(hit.resource));
 			} else {
-				hits = hits.filter((hit) => hit.resource === resource);
+				hits = hits.filter((hit) => !hit.resource || hit.resource === resource);
 			}
 			if (hits.length < beforeResourceFilter) {
 				clientSideFiltersApplied.push(`resource:${resource}`);
 			}
 		}
 
-		// Language filter - check if AutoRAG honored it
+		// Language filter - only filter if hit has language AND it doesn't match
+		// (don't filter out hits missing the language field - AutoRAG may not return it)
 		if (language) {
 			const beforeLangFilter = hits.length;
-			hits = hits.filter((hit) => hit.language === language);
+			hits = hits.filter((hit) => !hit.language || hit.language === language);
 			if (hits.length < beforeLangFilter) {
 				clientSideFiltersApplied.push(`language:${language}`);
 			}
 		}
 
-		// Organization filter - check if AutoRAG honored it
+		// Organization filter - only filter if hit has org AND it doesn't match
+		// (don't filter out hits missing the organization field)
 		if (organization) {
 			const beforeOrgFilter = hits.length;
-			hits = hits.filter((hit) => hit.organization === organization);
+			hits = hits.filter((hit) => !hit.organization || hit.organization === organization);
 			if (hits.length < beforeOrgFilter) {
 				clientSideFiltersApplied.push(`organization:${organization}`);
 			}
 		}
 
-		// Book filter - check if AutoRAG honored it
+		// Book filter - only filter if hit has book AND it doesn't match
 		const bookFilter = bookParam || parsedRef?.book;
 		if (bookFilter) {
 			const beforeBookFilter = hits.length;
-			hits = hits.filter((hit) => hit.book?.toUpperCase() === bookFilter.toUpperCase());
+			hits = hits.filter((hit) => !hit.book || hit.book.toUpperCase() === bookFilter.toUpperCase());
 			if (hits.length < beforeBookFilter) {
 				clientSideFiltersApplied.push(`book:${bookFilter}`);
 			}
 		}
 
-		// Chapter filter - check if AutoRAG honored it
+		// Chapter filter - only filter if hit has chapter AND it doesn't match
 		const chapterFilter = chapterParam ?? parsedRef?.chapter;
 		if (chapterFilter !== undefined) {
 			const beforeChapterFilter = hits.length;
-			hits = hits.filter((hit) => hit.chapter === chapterFilter);
+			hits = hits.filter((hit) => hit.chapter === undefined || hit.chapter === chapterFilter);
 			if (hits.length < beforeChapterFilter) {
 				clientSideFiltersApplied.push(`chapter:${chapterFilter}`);
 			}
 		}
 
-		// Chunk level filter - check if AutoRAG honored it
+		// Chunk level filter - only filter if hit has chunk_level AND it doesn't match
 		if (chunk_level) {
 			const beforeChunkFilter = hits.length;
-			hits = hits.filter((hit) => hit.chunk_level === chunk_level);
+			hits = hits.filter((hit) => !hit.chunk_level || hit.chunk_level === chunk_level);
 			if (hits.length < beforeChunkFilter) {
 				clientSideFiltersApplied.push(`chunk_level:${chunk_level}`);
 			}
 		}
 
-		// Article ID filter - check if AutoRAG honored it
+		// Article ID filter - only filter if hit has article_id AND it doesn't match
 		if (articleId) {
 			const beforeArticleFilter = hits.length;
-			hits = hits.filter((hit) => hit.article_id?.toLowerCase() === articleId.toLowerCase());
+			hits = hits.filter((hit) => !hit.article_id || hit.article_id.toLowerCase() === articleId.toLowerCase());
 			if (hits.length < beforeArticleFilter) {
 				clientSideFiltersApplied.push(`article_id:${articleId}`);
 			}

--- a/ui/src/routes/api/search/+server.ts
+++ b/ui/src/routes/api/search/+server.ts
@@ -537,11 +537,13 @@ async function executeSearch(
 			const aiSearchStart = Date.now();
 			const autorag = ai.autorag(AI_SEARCH_INDEX);
 
-			// When filtering by scripture/bible alias, request MORE results from AutoRAG
+			// When filtering by scripture/bible alias, request max results from AutoRAG
 			// since we need to filter client-side and scripture may rank lower in vector search
+			// Note: AutoRAG has a hard limit of 50 results max
+			const AUTORAG_MAX_RESULTS = 50;
 			const fetchLimit = isScriptureAlias 
-				? Math.min(Math.max(limit * 10, 100), 500)  // Fetch 10x requested or at least 100, max 500
-				: Math.min(limit, 100);
+				? AUTORAG_MAX_RESULTS  // Always fetch max when client-side filtering
+				: Math.min(limit, AUTORAG_MAX_RESULTS);
 
 			const searchOptions = {
 				query,

--- a/ui/src/routes/api/search/+server.ts
+++ b/ui/src/routes/api/search/+server.ts
@@ -724,8 +724,9 @@ async function executeSearch(
 		}
 
 		// Include helps filter (exclude helps if false)
+		// Be lenient: if resource is missing, keep the hit (don't filter out)
 		if (!includeHelps) {
-			hits = hits.filter((hit) => SCRIPTURE_RESOURCES.includes(hit.resource));
+			hits = hits.filter((hit) => !hit.resource || SCRIPTURE_RESOURCES.includes(hit.resource));
 		}
 
 		// Log diagnostic info about filter effectiveness

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,6 +27,21 @@ compatibility_flags = ["nodejs_compat"]
 [env.preview.vars]
   NODE_ENV = "development"
 
+  # AI binding for preview (for Workers AI / AI Search on deploy previews)
+  [env.preview.ai]
+  binding = "AI"
+
+  # KV namespace for preview
+  [[env.preview.kv_namespaces]]
+  binding = "TRANSLATION_HELPS_CACHE"
+  id = "116847d7b0714a9c8d2882335b05d35a"
+  preview_id = "3073e58cc3eb4f16958854a6ec1531e6"
+
+  # R2 bucket for preview
+  [[env.preview.r2_buckets]]
+  binding = "ZIP_FILES"
+  bucket_name = "translation-helps-mcp-zip-persistence"
+
 # KV Namespace binding (you'll need to create this in Cloudflare dashboard)
 # Run: npx wrangler kv namespace create "TRANSLATION_HELPS_CACHE"
 # Then update the id below with the actual namespace ID


### PR DESCRIPTION
Add client-side filtering for all search parameters to ensure accurate results when AutoRAG fails to honor filters.

Previously, the search endpoint relied solely on Cloudflare AutoRAG to apply filters like `resource`, `language`, and `book`. However, AutoRAG was not consistently honoring these filters, leading to unfiltered or incorrectly filtered search results. This PR introduces a client-side fallback mechanism to re-apply all specified filters after results are returned from AutoRAG, guaranteeing correct filtering. Diagnostic logging is also included to identify which filters AutoRAG is not respecting.

---
<a href="https://cursor.com/background-agent?bcId=bc-dab048bb-d66e-4689-b44f-29177cee4084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dab048bb-d66e-4689-b44f-29177cee4084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive client-side enforcement of search filters with diagnostics when AutoRAG misses them.
> 
> - **Backend/API (`ui/src/routes/api/search/+server.ts`)**:
>   - **Client-side filter enforcement**: Apply `resource` (incl. `scripture`/`bible` aliases), `language`, `organization`, `book`, `chapter`, `chunk_level`, and `articleId` after formatting results; record `clientSideFiltersApplied` and counts.
>   - **Scripture aliases**: Introduce `SCRIPTURE_RESOURCES` (`ult`, `ust`, `ueb`, `t4t`, `scripture`) and use for `resource` and `includeHelps` filtering.
>   - **Diagnostics & tracing**: Log warning when client-side filters remove results; add tracing for filter/sort step and include before/after metrics.
>   - **Sorting**: Ensure final results are sorted by `score` desc.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 795905314ed644242743b9ad8f82c445c0448adc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->